### PR TITLE
Add build-push-image-configurable workflow step definition.

### DIFF
--- a/infra/modules/kubevela/definitions/build-push-image-configurable.cue
+++ b/infra/modules/kubevela/definitions/build-push-image-configurable.cue
@@ -1,0 +1,172 @@
+import (
+	"vela/op"
+	"encoding/json"
+	"strings"
+)
+
+// TODO find a way to import the upstream version and just add config on top, or what is CUE for?
+"build-push-image-configurable": {
+	alias: ""
+	attributes: {}
+	description: "Build and push image from git url (more configurable than upstream)"
+	annotations: {
+		"category": "CI Integration"
+	}
+	labels: {}
+	type: "workflow-step"
+}
+
+template: {
+	url: {
+		if parameter.context.git != _|_ {
+			address: strings.TrimPrefix(parameter.context.git, "git://")
+			value:   "git://\(address)#refs/heads/\(parameter.context.branch)"
+		}
+		if parameter.context.git == _|_ {
+			value: parameter.context
+		}
+	}
+	kaniko: op.#Apply & {
+		value: {
+			apiVersion: "v1"
+			kind:       "Pod"
+			metadata: {
+				name:      "\(context.name)-\(context.stepSessionID)-kaniko"
+				namespace: context.namespace
+			}
+			spec: {
+				containers: [
+					{
+						args: [
+							"--dockerfile=\(parameter.dockerfile)",
+							"--context=\(url.value)",
+							"--destination=\(parameter.image)",
+							"--verbosity=\(parameter.verbosity)",
+							if parameter.platform != _|_ {
+								"--customPlatform=\(parameter.platform)"
+							},
+							if parameter.buildArgs != _|_ for arg in parameter.buildArgs {
+								"--build-arg=\(arg)"
+							},
+						]
+						image: parameter.kanikoExecutor
+						if parameter.requests != _|_ && parameter.requests.ephemeralStorage != _|_ {
+							resources: {
+								requests: {
+									"ephemeral-storage": parameter.requests.ephemeralStorage
+								}
+							}
+						}
+						name:  "kaniko"
+						if parameter.credentials != _|_ && parameter.credentials.image != _|_ {
+							volumeMounts: [
+								{
+									mountPath: "/kaniko/.docker/"
+									name:      parameter.credentials.image.name
+								},
+							]
+						}
+						if parameter.credentials != _|_ && parameter.credentials.git != _|_ {
+							env: [
+								{
+									name: "GIT_TOKEN"
+									valueFrom: {
+										secretKeyRef: {
+											key:  parameter.credentials.git.key
+											name: parameter.credentials.git.name
+										}
+									}
+								},
+							]
+						}
+					},
+				]
+				if parameter.credentials != _|_ && parameter.credentials.image != _|_ {
+					volumes: [
+						{
+							name: parameter.credentials.image.name
+							secret: {
+								defaultMode: 420
+								items: [
+									{
+										key:  parameter.credentials.image.key
+										path: "config.json"
+									},
+								]
+								secretName: parameter.credentials.image.name
+							}
+						},
+					]
+				}
+				restartPolicy: "Never"
+			}
+		}
+	}
+	log: op.#Log & {
+		source: {
+			resources: [{
+				name:      "\(context.name)-\(context.stepSessionID)-kaniko"
+				namespace: context.namespace
+			}]
+		}
+	}
+	read: op.#Read & {
+		value: {
+			apiVersion: "v1"
+			kind:       "Pod"
+			metadata: {
+				name:      "\(context.name)-\(context.stepSessionID)-kaniko"
+				namespace: context.namespace
+			}
+		}
+	}
+	wait: op.#ConditionalWait & {
+		continue: read.value.status != _|_ && read.value.status.phase == "Succeeded"
+	}
+	#secret: {
+		name: string
+		key:  string
+	}
+	#git: {
+		git:    string
+		branch: *"master" | string
+	}
+	parameter: {
+		// +usage=Specify the kaniko executor image, default to oamdev/kaniko-executor:v1.9.1
+		kanikoExecutor: *"oamdev/kaniko-executor:v1.9.1" | string
+		// +usage=Specify the context to build image, you can use context with git and branch or directly specify the context, please refer to https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts
+		context: #git | string
+		// +usage=Specify the dockerfile
+		dockerfile: *"./Dockerfile" | string
+		// +usage=Specify the image
+		image: string
+		// +usage=Specify the platform to build
+		platform?: string
+		// +usage=Specify the build args
+		buildArgs?: [...string]
+		// +usage=Specify the credentials to access git and image registry
+		credentials?: {
+			// +usage=Specify the credentials to access git
+			git?: {
+				// +usage=Specify the secret name
+				name: string
+				// +usage=Specify the secret key
+				key: string
+			}
+			// +usage=Specify the credentials to access image registry
+			image?: {
+				// +usage=Specify the secret name
+				name: string
+				// +usage=Specify the secret key
+				key: *".dockerconfigjson" | string
+			}
+		}
+		// +usage=Specify resource requests for the kaniko build
+		requests?: {
+			// +usage=Request a specified storage size
+			ephemeralStorage?: string
+		}
+		// +usage=Specify the verbosity level
+		verbosity: *"info" | "panic" | "fatal" | "error" | "warn" | "debug" | "trace"
+	}
+}

--- a/infra/modules/kubevela/definitions/build-push-image-configurable.cue
+++ b/infra/modules/kubevela/definitions/build-push-image-configurable.cue
@@ -42,6 +42,7 @@ template: {
 							"--context=\(url.value)",
 							"--destination=\(parameter.image)",
 							"--verbosity=\(parameter.verbosity)",
+							"--snapshot-mode=\(parameter.snapshotMode)",
 							if parameter.platform != _|_ {
 								"--customPlatform=\(parameter.platform)"
 							},
@@ -171,6 +172,8 @@ template: {
 		}
 		// +usage=Set the --single-snapshot flag https://github.com/GoogleContainerTools/kaniko#flag---single-snapshot
 		singleSnapshot: *false | true
+		// +usage=Set the --snapshot-mode flag https://github.com/GoogleContainerTools/kaniko#flag---single-snaphot-mode
+		snapshotMode: *"full" | "redo" | "time"
 		// +usage=Specify the verbosity level
 		verbosity: *"info" | "panic" | "fatal" | "error" | "warn" | "debug" | "trace"
 	}

--- a/infra/modules/kubevela/definitions/build-push-image-configurable.cue
+++ b/infra/modules/kubevela/definitions/build-push-image-configurable.cue
@@ -48,6 +48,9 @@ template: {
 							if parameter.buildArgs != _|_ for arg in parameter.buildArgs {
 								"--build-arg=\(arg)"
 							},
+							if parameter.singleSnapshot {
+								"--single-snapshot"
+							},
 						]
 						image: parameter.kanikoExecutor
 						if parameter.requests != _|_ && parameter.requests.ephemeralStorage != _|_ {
@@ -166,6 +169,8 @@ template: {
 			// +usage=Request a specified storage size
 			ephemeralStorage?: string
 		}
+		// +usage=Set the --single-snapshot flag https://github.com/GoogleContainerTools/kaniko#flag---single-snapshot
+		singleSnapshot: *false | true
 		// +usage=Specify the verbosity level
 		verbosity: *"info" | "panic" | "fatal" | "error" | "warn" | "debug" | "trace"
 	}

--- a/infra/nix-docker-builder/Dockerfile
+++ b/infra/nix-docker-builder/Dockerfile
@@ -32,7 +32,6 @@ WORKDIR /tmp
 
 # Copy /nix/store
 COPY --from=builder /workspace/tmp/nix-store-closure /nix/store
-COPY --from=builder /workspace/tmp/root/bin /
-COPY --from=builder /workspace/tmp/root/etc /
+COPY --from=builder /workspace/tmp/root /
 COPY --from=builder /workspace/tmp/build/entrypoint /entrypoint
 ENTRYPOINT ["/entrypoint"]

--- a/infra/nix-docker-builder/Dockerfile
+++ b/infra/nix-docker-builder/Dockerfile
@@ -24,10 +24,10 @@ RUN rm -fR /nix
 # but they're fully self-contained so we don't need Nix anymore.
 FROM scratch
 
-WORKDIR /workspace/tmp
+WORKDIR /
 
 # Copy /nix/store
 COPY --from=builder /workspace/tmp/nix-store-closure /nix/store
 COPY --from=builder /workspace/tmp/build/.nix-profile /
 COPY --from=builder /workspace/tmp/build/entrypoint /entrypoint
-CMD ["/entrypoint"]
+ENTRYPOINT ["/entrypoint"]

--- a/infra/nix-docker-builder/Dockerfile
+++ b/infra/nix-docker-builder/Dockerfile
@@ -16,8 +16,8 @@ RUN HOME=/workspace/tmp/build nix \
 # Copy the Nix store closure into a directory. The Nix store closure is the
 # entire set of Nix store values that we need for our build.
 RUN mkdir -p /workspace/tmp/nix-store-closure
-RUN cp -R $(nix-store -qR /tmp/build/.nix-profile) /workspace/tmp/nix-store-closure
-RUN cp /tmp/build/.nix-profile/bin/$ENTRYPOINT_BIN_NAME /workspace/tmp/build/entrypoint
+RUN cp -R $(nix-store -qR /workspace/tmp/build/.nix-profile) /workspace/tmp/nix-store-closure
+RUN cp /workspace/tmp/build/.nix-profile/bin/$ENTRYPOINT_BIN_NAME /workspace/tmp/build/entrypoint
 RUN rm -fR /nix
 
 # Final image is based on scratch. We copy a bunch of Nix dependencies

--- a/infra/nix-docker-builder/Dockerfile
+++ b/infra/nix-docker-builder/Dockerfile
@@ -3,10 +3,10 @@ FROM nixos/nix:latest AS builder
 ARG ENTRYPOINT_BIN_NAME=bash
 ARG INCLUDED_FLAKE_URIS
 
-WORKDIR /tmp/build
+WORKDIR /workspace/tmp/build
 
 # Build our Nix environment
-RUN HOME=/tmp/build nix \
+RUN HOME=/workspace/tmp/build nix \
     --extra-experimental-features "nix-command flakes" \
     --option filter-syscalls false \
     --accept-flake-config \
@@ -15,20 +15,19 @@ RUN HOME=/tmp/build nix \
 
 # Copy the Nix store closure into a directory. The Nix store closure is the
 # entire set of Nix store values that we need for our build.
-RUN mkdir /tmp/nix-store-closure
-RUN cp -R $(nix-store -qR /tmp/build/.nix-profile) /tmp/nix-store-closure
-RUN cp /tmp/build/.nix-profile/bin/$ENTRYPOINT_BIN_NAME /tmp/build/entrypoint
-RUN mv /tmp/build/.nix-profile /tmp/build/nix-profile
-RUN HOME=/tmp/build nix-collect-garbage -d
+RUN mkdir -p /workspace/tmp/nix-store-closure
+RUN cp -R $(nix-store -qR /tmp/build/.nix-profile) /workspace/tmp/nix-store-closure
+RUN cp /tmp/build/.nix-profile/bin/$ENTRYPOINT_BIN_NAME /workspace/tmp/build/entrypoint
+RUN rm -fR /nix
 
 # Final image is based on scratch. We copy a bunch of Nix dependencies
 # but they're fully self-contained so we don't need Nix anymore.
 FROM scratch
 
-WORKDIR /tmp
+WORKDIR /workspace/tmp
 
 # Copy /nix/store
-COPY --from=builder /tmp/nix-store-closure /nix/store
-COPY --from=builder /tmp/build/nix-profile /
-COPY --from=builder /tmp/build/entrypoint /entrypoint
+COPY --from=builder /workspace/tmp/nix-store-closure /nix/store
+COPY --from=builder /workspace/tmp/build/.nix-profile /
+COPY --from=builder /workspace/tmp/build/entrypoint /entrypoint
 CMD ["/entrypoint"]

--- a/infra/nix-docker-builder/Dockerfile
+++ b/infra/nix-docker-builder/Dockerfile
@@ -18,8 +18,6 @@ RUN HOME=/tmp/build nix \
 RUN mkdir /tmp/nix-store-closure
 RUN cp -R $(nix-store -qR /tmp/build/.nix-profile) /tmp/nix-store-closure
 RUN cp /tmp/build/.nix-profile/bin/$ENTRYPOINT_BIN_NAME /tmp/build/entrypoint
-RUN mv /tmp/build/.nix-profile /tmp/build/nix-profile
-RUN HOME=/tmp/build nix-collect-garbage -d
 
 # Final image is based on scratch. We copy a bunch of Nix dependencies
 # but they're fully self-contained so we don't need Nix anymore.
@@ -29,6 +27,6 @@ WORKDIR /tmp
 
 # Copy /nix/store
 COPY --from=builder /tmp/nix-store-closure /nix/store
-COPY --from=builder /tmp/build/nix-profile /
+COPY --from=builder /tmp/build/.nix-profile /
 COPY --from=builder /tmp/build/entrypoint /entrypoint
 CMD ["/entrypoint"]

--- a/infra/nix-docker-builder/Dockerfile
+++ b/infra/nix-docker-builder/Dockerfile
@@ -18,7 +18,10 @@ RUN HOME=/workspace/tmp/build nix \
 RUN mkdir -p /workspace/tmp/nix-store-closure
 RUN cp -R $(nix-store -qR /workspace/tmp/build/.nix-profile) /workspace/tmp/nix-store-closure
 RUN cp /workspace/tmp/build/.nix-profile/bin/$ENTRYPOINT_BIN_NAME /workspace/tmp/build/entrypoint
-RUN ln -s $(readlink -f /workspace/tmp/build/.nix-profile) /workspace/tmp/nix-profile
+RUN mkdir -p /workspace/tmp/root/etc
+RUN cp -a /workspace/tmp/build/.nix-profile/bin /workspace/tmp/root/bin
+# /etc may be a symlink in the nix profile, but can't be on the image filesystem (the runtime needs to set up e.g. resolv.conf)
+RUN cp -a /workspace/tmp/build/.nix-profile/etc/* /workspace/tmp/root/etc
 RUN rm -fR /nix
 
 # Final image is based on scratch. We copy a bunch of Nix dependencies
@@ -29,7 +32,7 @@ WORKDIR /tmp
 
 # Copy /nix/store
 COPY --from=builder /workspace/tmp/nix-store-closure /nix/store
-COPY --from=builder /workspace/tmp/nix-profile /
+COPY --from=builder /workspace/tmp/root/bin /
+COPY --from=builder /workspace/tmp/root/etc /
 COPY --from=builder /workspace/tmp/build/entrypoint /entrypoint
-ENV PATH=/nix-profile/bin
 ENTRYPOINT ["/entrypoint"]

--- a/infra/nix-docker-builder/Dockerfile
+++ b/infra/nix-docker-builder/Dockerfile
@@ -10,7 +10,7 @@ RUN HOME=/workspace/tmp/build nix \
     --extra-experimental-features "nix-command flakes" \
     --option filter-syscalls false \
     --accept-flake-config \
-    profile install $INCLUDED_FLAKE_URIS nixpkgs\#bash
+    profile install $INCLUDED_FLAKE_URIS nixpkgs\#bash nixpkgs\#coreutils
 
 
 # Copy the Nix store closure into a directory. The Nix store closure is the
@@ -18,16 +18,18 @@ RUN HOME=/workspace/tmp/build nix \
 RUN mkdir -p /workspace/tmp/nix-store-closure
 RUN cp -R $(nix-store -qR /workspace/tmp/build/.nix-profile) /workspace/tmp/nix-store-closure
 RUN cp /workspace/tmp/build/.nix-profile/bin/$ENTRYPOINT_BIN_NAME /workspace/tmp/build/entrypoint
+RUN ln -s $(readlink -f /workspace/tmp/build/.nix-profile) /workspace/tmp/nix-profile
 RUN rm -fR /nix
 
 # Final image is based on scratch. We copy a bunch of Nix dependencies
 # but they're fully self-contained so we don't need Nix anymore.
 FROM scratch
 
-WORKDIR /
+WORKDIR /tmp
 
 # Copy /nix/store
 COPY --from=builder /workspace/tmp/nix-store-closure /nix/store
-COPY --from=builder /workspace/tmp/build/.nix-profile /
+COPY --from=builder /workspace/tmp/nix-profile /
 COPY --from=builder /workspace/tmp/build/entrypoint /entrypoint
+ENV PATH=/nix-profile/bin
 ENTRYPOINT ["/entrypoint"]

--- a/infra/nix-docker-builder/Dockerfile
+++ b/infra/nix-docker-builder/Dockerfile
@@ -18,6 +18,8 @@ RUN HOME=/tmp/build nix \
 RUN mkdir /tmp/nix-store-closure
 RUN cp -R $(nix-store -qR /tmp/build/.nix-profile) /tmp/nix-store-closure
 RUN cp /tmp/build/.nix-profile/bin/$ENTRYPOINT_BIN_NAME /tmp/build/entrypoint
+RUN mv /tmp/build/.nix-profile /tmp/build/nix-profile
+RUN HOME=/tmp/build nix-collect-garbage -d
 
 # Final image is based on scratch. We copy a bunch of Nix dependencies
 # but they're fully self-contained so we don't need Nix anymore.
@@ -27,6 +29,6 @@ WORKDIR /tmp
 
 # Copy /nix/store
 COPY --from=builder /tmp/nix-store-closure /nix/store
-COPY --from=builder /tmp/build/.nix-profile /
+COPY --from=builder /tmp/build/nix-profile /
 COPY --from=builder /tmp/build/entrypoint /entrypoint
 CMD ["/entrypoint"]


### PR DESCRIPTION
As-is, this has two problems but is better than nothing:

1. We should just override the upstream build-push-image rather than copy-pasting it. CUE in principle allows for this, but I couldn't find out if/how I can reference other workflow steps available in the Vela cluster
2. I was not able to add this via terraform, as the repo is missing files (at minimum helm.yaml).