### PR TITLE
Update Marlowe runtime infra configuration

### DIFF
--- a/infra/prod-us-east-1/k8s/eks/terragrunt.hcl
+++ b/infra/prod-us-east-1/k8s/eks/terragrunt.hcl
@@ -56,6 +56,7 @@ terraform {
 include {
   path = find_in_parent_folders()
 }
+
 # VPC as dependency
 dependency "vpc" {
   config_path = "../../vpc"

--- a/infra/prod-us-east-1/k8s/rds-postgres/terragrunt.hcl
+++ b/infra/prod-us-east-1/k8s/rds-postgres/terragrunt.hcl
@@ -1,0 +1,44 @@
+locals {
+
+  # Automatically load environment-level variables
+  account_vars     = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  # Extract out common variables for reuse
+  project        = local.account_vars.locals.project
+  app            = "marlowe-runtime"
+  database_name  = "${local.project}-${local.app}-database"
+
+  tags = {
+    Environment = "prod"
+    Terraform   = "true"
+    Project     = local.project
+    Resource    = local.database_name
+  }
+
+}
+
+terraform {
+  source = "github.com/terraform-aws-modules/terraform-aws-rds/modules/db_instance"
+}
+
+inputs = {
+  identifier            = local.database_name
+  instance_class        = "db.m5d.2xlarge"
+  multi_az              = true
+  max_allocated_storage = 3000
+
+  db_subnet_group_name   = "default-vpc-0a68a5d196ce5e1d1"
+  vpc_security_group_ids = ["sg-0c2ff87114e5f6ec1"]
+
+  snapshot_identifier     = "rds:runtime-database-1-2023-08-22-08-02"
+  skip_final_snapshot     = false
+  copy_tags_to_snapshot   = true
+  backup_retention_period = 21
+
+  performance_insights_enabled          = true
+  performance_insights_retention_period = 31
+
+  apply_immediately = true
+
+  tags = local.tags
+}


### PR DESCRIPTION
- Update Marlowe Runtime's mainnet cardano-node cpu spec (reverting a previous change) 
- Add terragrunt configuration for declarative setup of Marlowe Runtime's RDS Postgres Database 
- Add new empty line in EKS config (formatting)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced a new Terraform configuration for creating an RDS database instance in the production environment. This includes settings for instance class, multi-AZ deployment, storage allocation, subnet group, security group, snapshot identifier, backup retention period, and performance insights.
- Chore: Added explanatory comments to the existing Terraform configuration file for better understanding and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->