### PR TITLE
fix: remove Parthiv and add Daniel as cluster admins

### DIFF
--- a/infra/account.hcl
+++ b/infra/account.hcl
@@ -10,11 +10,10 @@ locals {
   # Allow users to access k8s over aws_auth config
   users = [
     # SRE
-    "parthiv.seetharaman",
     "olaniyi.oshunbote",
     "shea.levy",
+    "daniel.thagard",
     # TODO: Would be nice to autogenerate these
-    "vault-github-employees-Pacman99-admin-1675712570-y1IsbWJvNsTo2S1",
     "vault-github-employees-shlevy-admin-1675276763-1Llx839PFwXnsKIBx",
   ]
   domain = "dapps.aws.iohkdev.io"


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated user access permissions in the infrastructure configuration. Removed "parthiv.seetharaman" and added "daniel.thagard" to the list of allowed users.
- Refactor: Cleaned up the configuration by removing commented out autogenerated user.
- Chore: Changed the domain to "dapps.aws.iohkdev.io" for better alignment with our development environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->