### PR TITLE
chore: add direnv support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake . --impure


### PR DESCRIPTION
Adding support for [nix-direnv](https://github.com/nix-community/nix-direnv) for more convenient devshell usage.
This should have no effect on anybody not using direnv.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated the environment configuration to import the `flake` library with the `--impure` flag. This change is part of our ongoing efforts to improve the development environment setup and does not impact the end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->