### PR TITLE
infra: add cluster access for Rene and Oz

### DIFF
--- a/infra/account.hcl
+++ b/infra/account.hcl
@@ -13,8 +13,8 @@ locals {
     "olaniyi.oshunbote",
     "shea.levy",
     "daniel.thagard",
-    # TODO: Would be nice to autogenerate these
-    "vault-github-employees-shlevy-admin-1675276763-1Llx839PFwXnsKIBx",
+    "rene.barbosa",
+    "oguzhan.boran",
   ]
   domain = "dapps.aws.iohkdev.io"
 }


### PR DESCRIPTION
- remove `vault-github-employees-shlevy-admin-1675276763-1Llx839PFwXnsKIBx` which does not exist anymore.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated Terraform configuration in `infra/account.hcl`. Added two new users, "rene.barbosa" and "oguzhan.boran", to the list of locals. This change will allow these users to access and manage resources within our infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->