### PR TITLE
Resolve Traefik and KubeVela issues on Kubernetes 1.26

### DIFF
--- a/infra/modules/before_addons/letsencrypt_issuer.yaml
+++ b/infra/modules/before_addons/letsencrypt_issuer.yaml
@@ -10,10 +10,9 @@ spec:
       name: letsencrypt
     solvers:
     - http01:
-        ingress:
-          class: traefik
-          ingressTemplate:
-            metadata:
-              annotations:
-                traefik.ingress.kubernetes.io/router.tls: "true"
-                traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
+        gatewayHTTPRoute:
+          parentRefs:
+          - group: gateway.networking.k8s.io
+            kind: Gateway
+            name: traefik-gateway
+            namespace: traefik

--- a/infra/modules/kubevela/definitions/http-route.cue
+++ b/infra/modules/kubevela/definitions/http-route.cue
@@ -14,7 +14,7 @@ outputs: {
 				if parameter.gatewayName == _|_ {
 					name: "traefik-gateway"
 				}
-				namespace: "vela-system"
+				namespace: "traefik"
 				if parameter.listenerName != _|_ {
 					sectionName: parameter.listenerName
 				}

--- a/infra/prod-new-us-east-1/k8s/eks-addons/terragrunt.hcl
+++ b/infra/prod-new-us-east-1/k8s/eks-addons/terragrunt.hcl
@@ -82,7 +82,7 @@ inputs = {
       enabled      = true
       extra_values = <<-EXTRA_VALUES
         domainFilters:
-         - scdev-test.aws.iohkdev.io
+         - scdev.aws.iohkdev.io
          - play-test.marlowe.iohk.io
       EXTRA_VALUES
     }
@@ -98,11 +98,11 @@ inputs = {
           enabled: true
       service:
         annotations:
-          "external-dns.alpha.kubernetes.io/hostname": "*.scdev-test.aws.iohkdev.io,play-test.marlowe.iohk.io"
+          "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing"
+          "external-dns.alpha.kubernetes.io/hostname": "*.test.scdev.aws.iohkdev.io,fun.test.scdev.aws.iohkdev.io,play-test.marlowe.iohk.io"
       ports:
         web:
           redirectTo: websecure
-
     EXTRA_VALUES
 
   }


### PR DESCRIPTION
This PR contains fixes found by @renebarbosafl that were preventing Traefik from working properly with KubeVela when deployed on Kubernetes 1.26.
These include:
- Services of type LoadBalancer previously deployed a Classic ELB, and now deploy a Network ELB, which requires an annotation to expose to the internet
- The Let's Encrypt ClusterIssuer's HTTP solver must be updated to use the Gateway API
- the HTTP route trait must reflect that the traefik-gateway is in the traefik namespace
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the Kubernetes namespace in `http-route.cue` from `"vela-system"` to `"traefik"`, enhancing routing capabilities.
- New Feature: Modified domain filters and annotations in `terragrunt.hcl`. Replaced `scdev-test.aws.iohkdev.io` with `scdev.aws.iohkdev.io` and added new domain filters, expanding our service's reach.
- New Feature: Updated the `external-dns.alpha.kubernetes.io/hostname` annotation to include new domains, improving DNS management.
- New Feature: Added `service.beta.kubernetes.io/aws-load-balancer-scheme` annotation with the value "internet-facing", enabling better load balancing for external traffic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->