### PR TITLE
set nixpkgs flake input to 23.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -925,16 +925,18 @@
     },
     "nixpkgs_16": {
       "locked": {
-        "lastModified": 1678268259,
-        "narHash": "sha256-q+ZWNJfXKgIKwsZBir0yXrmIV/4tOv5BflxDAfGISps=",
+        "lastModified": 1685566663,
+        "narHash": "sha256-btHN1czJ6rzteeCuE/PNrdssqYD2nIA4w48miQAFloM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90ef5c3c337d8d9f0c97e7641ece70a41f6c16a2",
+        "rev": "4ecab3273592f27479a583fb6d975d4aba3486fe",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "23.05",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_2": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,17 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     capsules.url = "github:input-output-hk/devshell-capsules";
     devenv.url = "github:cachix/devenv";
+    nixpkgs.url = "github:NixOS/nixpkgs/23.05";
   };
-  outputs = inputs@{ self, flake-parts, devenv, capsules, nixpkgs, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
+  outputs = inputs @ {
+    self,
+    flake-parts,
+    devenv,
+    capsules,
+    nixpkgs,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
       systems = [
         "x86_64-linux"
         "x86_64-darwin"
@@ -16,13 +24,19 @@
         devenvModules = import ./devenvModules;
       };
       # Flake outputs that will be split by system
-      perSystem = { config, pkgs, inputs', self', ... }: {
-        packages = import ./packages { inherit pkgs inputs'; };
+      perSystem = {
+        config,
+        pkgs,
+        inputs',
+        self',
+        ...
+      }: {
+        packages = import ./packages {inherit pkgs inputs';};
 
         devShells = {
           default = devenv.lib.mkShell {
             inherit pkgs;
-            inputs = inputs // { inherit inputs' self'; };
+            inputs = inputs // {inherit inputs' self';};
             modules = [
               self.devenvModules.metal
               self.devenvModules.cloud


### PR DESCRIPTION
Not pinning the nixpkgs input in flake.nix means that we are living at HEAD of nixpkgs for all dependencies. With this PR, we would follow the 23.05 nixpkgs release.
This will keep terraform < 1.6 for now, maintaining compatibility with terragrunt.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Improved the organization and readability of the Nix flake configuration, making it easier for developers to understand and modify.
- New Feature: Expanded the `perSystem` and `devShells` attributes, enhancing the flexibility and functionality of the system.
- Refactor: Updated the `packages` attribute to import from a new location, streamlining the package management process.

These changes primarily benefit developers working with the Nix flake configuration, enhancing its usability and flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->