### PR TITLE
move config that differs between clusters to env.hcl

### DIFF
--- a/infra/prod-new-us-east-1/env.hcl
+++ b/infra/prod-new-us-east-1/env.hcl
@@ -6,7 +6,9 @@ locals {
   project     = "dapps"
   namespaces  = ["preprod-prod", "mainnet-prod"]
   clustername = "${local.project}-${local.environment}-${local.aws_region}"
-  domain      = "dapps.aws.iohkdev.io"
+
+  # This will generate A records for these domains pointing to Traefik's ELB
+  hostnames = ["*.test.scdev.aws.iohkdev.io"]
 
   cidr_prefix = "10.30"
 }

--- a/infra/prod-new-us-east-1/env.hcl
+++ b/infra/prod-new-us-east-1/env.hcl
@@ -1,10 +1,12 @@
 # Set common variables for the environment. This is automatically pulled in in the root terragrunt.hcl configuration to
 # feed forward to the child modules.
 locals {
-  aws_region = "us-east-1"
+  aws_region  = "us-east-1"
   environment = "prod-new"
   project     = "dapps"
-  namespaces =  [ "preprod-prod", "mainnet-prod" ]
+  namespaces  = ["preprod-prod", "mainnet-prod"]
   clustername = "${local.project}-${local.environment}-${local.aws_region}"
-  domain = "dapps.aws.iohkdev.io"
+  domain      = "dapps.aws.iohkdev.io"
+
+  cidr_prefix = "10.30"
 }

--- a/infra/prod-new-us-east-1/k8s/eks-addons/terragrunt.hcl
+++ b/infra/prod-new-us-east-1/k8s/eks-addons/terragrunt.hcl
@@ -16,9 +16,10 @@ locals {
   environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
   account_vars     = read_terragrunt_config(find_in_parent_folders("account.hcl"))
   # Extract out common variables for reuse
-  env     = local.environment_vars.locals.environment
-  region  = local.environment_vars.locals.aws_region
-  profile = local.account_vars.locals.aws_profile
+  env       = local.environment_vars.locals.environment
+  region    = local.environment_vars.locals.aws_region
+  profile   = local.account_vars.locals.aws_profile
+  hostnames = local.environment_vars.locals.hostnames
 }
 
 generate = merge(local.k8s.generate, local.helm.generate, local.kubectl.generate)
@@ -83,7 +84,8 @@ inputs = {
       extra_values = <<-EXTRA_VALUES
         domainFilters:
          - scdev.aws.iohkdev.io
-         - play-test.marlowe.iohk.io
+         - play.marlowe.iohk.io
+         - runner.marlowe.iohk.io
       EXTRA_VALUES
     }
   }
@@ -99,7 +101,7 @@ inputs = {
       service:
         annotations:
           "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing"
-          "external-dns.alpha.kubernetes.io/hostname": "*.test.scdev.aws.iohkdev.io,fun.test.scdev.aws.iohkdev.io,play-test.marlowe.iohk.io"
+          "external-dns.alpha.kubernetes.io/hostname": "${join(",", local.hostnames)}"
       ports:
         web:
           redirectTo: websecure

--- a/infra/prod-new-us-east-1/vpc/terragrunt.hcl
+++ b/infra/prod-new-us-east-1/vpc/terragrunt.hcl
@@ -3,10 +3,11 @@ locals {
   environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
   account_vars     = read_terragrunt_config(find_in_parent_folders("account.hcl"))
   # Extract out common variables for reuse
-  env     = local.environment_vars.locals.environment
-  region  = local.environment_vars.locals.aws_region
-  project = local.account_vars.locals.project
-  name    = "${local.project}-${local.env}-${local.region}"
+  env         = local.environment_vars.locals.environment
+  region      = local.environment_vars.locals.aws_region
+  cidr_prefix = local.environment_vars.locals.cidr_prefix
+  project     = local.account_vars.locals.project
+  name        = "${local.project}-${local.env}-${local.region}"
 }
 
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
@@ -23,12 +24,12 @@ include {
 # These are the variables we have to pass in to use the module specified in the terragrunt configuration above
 inputs = {
   name = local.name
-  cidr = "10.30.0.0/16"
+  cidr = "${local.cidr_prefix}.0.0/16"
 
   azs             = ["${local.region}a", "${local.region}b", "${local.region}c"]
-  private_subnets = ["10.30.48.0/20", "10.30.64.0/20", "10.30.80.0/20"]   # /20 will allow 4096 ips per subnet
-  public_subnets  = ["10.30.0.0/20", "10.30.16.0/20", "10.30.32.0/20"]    # /20 will allow 4096 ips per subnet
-  intra_subnets   = ["10.30.96.0/22", "10.30.100.0/22", "10.30.104.0/22"] # /22 will allow 1024 ips per subnet
+  private_subnets = ["${local.cidr_prefix}.48.0/20", "${local.cidr_prefix}.64.0/20", "${local.cidr_prefix}.80.0/20"]   # /20 will allow 4096 ips per subnet
+  public_subnets  = ["${local.cidr_prefix}.0.0/20", "${local.cidr_prefix}.16.0/20", "${local.cidr_prefix}.32.0/20"]    # /20 will allow 4096 ips per subnet
+  intra_subnets   = ["${local.cidr_prefix}.96.0/22", "${local.cidr_prefix}.100.0/22", "${local.cidr_prefix}.104.0/22"] # /22 will allow 1024 ips per subnet
 
   enable_nat_gateway     = true
   single_nat_gateway     = true


### PR DESCRIPTION
CIDR blocks and which domain A records are being created can differ between clusters. All config that differs between clusters should be in env.hcl, to improve the ease of creating new clusters.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added support for the "aarch64-darwin" system, expanding the range of compatible devices.
- New Feature: Introduced a new Kubernetes cluster and context for improved workload management.
- New Feature: Implemented additional Kubernetes resources to be deployed before EKS Addons, enhancing the system's flexibility.
- New Feature: Added a new Terraform resource block to apply a Kubernetes manifest file, improving the system's configurability.
- New Feature: Introduced three new variables for customizing the deployment of kubevela and default Helm behavior.
- New Feature: Added a new Terraform configuration file for creating an AWS KMS key, enhancing data security.
- New Feature: Introduced a Bash script to calculate the maximum number of pods allowed on a Kubernetes worker node, optimizing resource usage.
- New Feature: Added a new Terraform configuration file for creating an RDS database, improving data management capabilities.
- New Feature: Introduced a new Terraform configuration file for setting up a VPC, enhancing network management.
- New Feature: Added a new Terraform module for creating an EC2 instance, expanding infrastructure capabilities.
- New Feature: Introduced a new Terraform module for creating an AWS key pair, enhancing security.
- New Feature: Added a new Terraform module for creating a security group for an AWS EC2 instance, improving network security.
- Improvement: Updated the Terraform source version for the VPC module, ensuring compatibility and stability.
- Improvement: Enhanced the configuration for the "kubernetes" provider, improving system reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->