### PR TITLE
add marlowe domain to external DNS on new cluster

### DIFF
--- a/infra/us-east-1/prod/env.hcl
+++ b/infra/us-east-1/prod/env.hcl
@@ -5,6 +5,6 @@ locals {
   environment = "prod"
   project     = "scde"
   # This will generate A records for these domains pointing to Traefik's ELB
-  hostnames   = ["*.test.scdev.aws.iohkdev.io"]
+  hostnames   = ["*.test.scdev.aws.iohkdev.io", "*.marlowe.iohk.io"]
   cidr_prefix = "10.30"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- New Feature: We've added a new domain, "*.marlowe.iohk.io", to our network. This update will enhance our system's accessibility by providing a new entry point for users. The new domain will direct traffic to our main server, ensuring a seamless and reliable user experience. Please note that the new domain might take some time to propagate across all regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->