### PR TITLE
chore: add acm module outputs and remove some sg rules

### DIFF
--- a/infra/modules/acm/outputs.tf
+++ b/infra/modules/acm/outputs.tf
@@ -1,0 +1,3 @@
+output "acm_certificate_arns" {
+  value = values(module.acm).*.acm_certificate_arn
+}

--- a/infra/us-east-1/prod/acm/terragrunt.hcl
+++ b/infra/us-east-1/prod/acm/terragrunt.hcl
@@ -15,7 +15,7 @@ include {
 }
 
 terraform {
-  source = "github.com/input-output-hk/sc-dev-platform.git//infra/modules/acm?ref=8461d7876cb82ca9c4971b53415a0f60863f0b48"
+  source = "github.com/input-output-hk/sc-dev-platform.git//infra/modules/acm?ref=205be46cf8fc5f93f4dffaaab35fb783dfd811dc"
 }
 
 inputs = {

--- a/infra/us-east-1/prod/eks/blue/eks/terragrunt.hcl
+++ b/infra/us-east-1/prod/eks/blue/eks/terragrunt.hcl
@@ -36,7 +36,7 @@ locals {
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
-  source = "github.com/input-output-hk/sc-dev-platform.git//infra/modules/eks?ref=5d2f55141b239e9c842121c707d24a53be496acc"
+  source = "github.com/input-output-hk/sc-dev-platform.git//infra/modules/eks"
 }
 
 # Include all settings from the root terragrunt.hcl file
@@ -75,54 +75,6 @@ inputs = {
       protocol                      = "-1"
       type                          = "ingress"
       source_cluster_security_group = true
-    }
-    ingress_node_port_tcp_1 = {
-      from_port        = 1025
-      to_port          = 5472 # Exclude calico-typha port 5473
-      protocol         = "tcp"
-      type             = "ingress"
-      cidr_blocks      = ["0.0.0.0/0"]
-      ipv6_cidr_blocks = ["::/0"]
-    }
-    ingress_node_port_tcp_2 = {
-      from_port        = 5474
-      to_port          = 10249 # Exclude kubelet port 10250
-      protocol         = "tcp"
-      type             = "ingress"
-      cidr_blocks      = ["0.0.0.0/0"]
-      ipv6_cidr_blocks = ["::/0"]
-    }
-    ingress_node_port_tcp_3 = {
-      from_port        = 10251
-      to_port          = 10255 # Exclude kube-proxy HCHK port 10256
-      protocol         = "tcp"
-      type             = "ingress"
-      cidr_blocks      = ["0.0.0.0/0"]
-      ipv6_cidr_blocks = ["::/0"]
-    }
-    ingress_node_port_tcp_4 = {
-      from_port        = 10257
-      to_port          = 61677 # Exclude aws-node port 61678
-      protocol         = "tcp"
-      type             = "ingress"
-      cidr_blocks      = ["0.0.0.0/0"]
-      ipv6_cidr_blocks = ["::/0"]
-    }
-    ingress_node_port_tcp_5 = {
-      from_port        = 61679
-      to_port          = 65535
-      protocol         = "tcp"
-      type             = "ingress"
-      cidr_blocks      = ["0.0.0.0/0"]
-      ipv6_cidr_blocks = ["::/0"]
-    }
-    ingress_node_port_udp = {
-      from_port        = 1025
-      to_port          = 65535
-      protocol         = "udp"
-      type             = "ingress"
-      cidr_blocks      = ["0.0.0.0/0"]
-      ipv6_cidr_blocks = ["::/0"]
     }
     egress_all = {
       from_port        = 0

--- a/infra/us-east-1/prod/eks/blue/eks/terragrunt.hcl
+++ b/infra/us-east-1/prod/eks/blue/eks/terragrunt.hcl
@@ -36,7 +36,7 @@ locals {
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
-  source = "github.com/input-output-hk/sc-dev-platform.git//infra/modules/eks"
+  source = "github.com/input-output-hk/sc-dev-platform.git//infra/modules/eks?ref=5d2f55141b239e9c842121c707d24a53be496acc"
 }
 
 # Include all settings from the root terragrunt.hcl file


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Chores:
- Updated the `acm` module in the `sc-dev-platform` repository. The Terraform source reference has been updated to a new commit, ensuring the module is up-to-date with the latest changes.
- Exported the `acm_certificate_arns` output from the `module.acm`. This change allows other modules or resources to access the Amazon Certificate Manager (ACM) Certificate ARNs, enhancing the interoperability within the infrastructure.

Refactor:
- Modified the Terraform configuration file for the `eks/blue/eks` module. The specific commit reference in the `source` parameter has been removed, enabling the use of the latest version of the code. This change improves maintainability and flexibility.

Bug Fixes:
- Removed several ingress rules for TCP and UDP ports in a security group. The removed rules included ranges of ports used by various Kubernetes components. This fix ensures that only necessary ingress traffic is allowed, enhancing security.

End-User Impact:
- The updated `acm` module and exported output provide improved integration capabilities for other modules or resources, enabling easier management of ACM certificates.
- The modified Terraform configuration file allows for seamless updates to the latest version of the code, ensuring stability and compatibility.
- The bug fix in the security group rules enhances the security posture of the infrastructure, reducing the risk of unauthorized access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->