### PR TITLE
add prod domain for DNS migration

### DIFF
--- a/infra/us-east-1/prod/acm/terragrunt.hcl
+++ b/infra/us-east-1/prod/acm/terragrunt.hcl
@@ -15,7 +15,7 @@ include {
 }
 
 terraform {
-  source = "github.com/input-output-hk/sc-dev-platform.git//infra/modules/acm?ref=205be46cf8fc5f93f4dffaaab35fb783dfd811dc"
+  source = "../../../modules/acm"
 }
 
 inputs = {

--- a/infra/us-east-1/prod/env.hcl
+++ b/infra/us-east-1/prod/env.hcl
@@ -9,6 +9,7 @@ locals {
   # ACM: Certificates and DNS Records to validate certificates
   # IAM: Policies allowing External-DNS to use Route53
   route53_config = {
+    "scdev.aws.iohkdev.io"      = "Z10147571DRRDCJXSER5Y"
     "test.scdev.aws.iohkdev.io" = "Z10147571DRRDCJXSER5Y"
     "marlowe.iohk.io"           = "Z0440193WFXP2UUTHQ1S"
   }


### PR DESCRIPTION
PR for activating the new cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Infrastructure Updates**
	- Updated the source reference for the ACM module in the Terraform configuration.
	- Added a new domain to the Route53 configuration, improving DNS record management and certificate handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->