### PR TITLE
fix: dex allowedOrigins type mismatch

### DIFF
--- a/infra/modules/kubevela-addons/dex.tf
+++ b/infra/modules/kubevela-addons/dex.tf
@@ -50,7 +50,7 @@ resource "kubernetes_secret" "dex-config" {
         http = "",
       }
       web = {
-        allowedOrigins = "null",
+        allowedOrigins = [],
         http           = "0.0.0.0:5556",
         https          = "",
         tlsCert        = "",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the configuration of the Kubernetes secret "dex-config" to improve security by modifying the `allowedOrigins` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->