### PR TITLE
updating https-route trait to use ingress-nginx

### DIFF
--- a/infra/modules/kubevela-addons/definitions.tf
+++ b/infra/modules/kubevela-addons/definitions.tf
@@ -4,14 +4,14 @@ resource "kubernetes_manifest" "traitdefinition_https_route" {
     "kind"       = "TraitDefinition"
     "metadata" = {
       "annotations" = {
-        "definition.oam.dev/description" = "defines HTTPS rules for mapping requests from a Gateway to Application."
+        "definition.oam.dev/description" = "defines HTTPS rules for mapping requests from an Ingress to Application."
       }
       "name"      = "https-route"
       "namespace" = var.namespace
     }
     "spec" = {
       "appliesToWorkloads" = [
-        "*",
+        "deployments.apps", "statefulsets.apps"
       ]
       "conflictsWith" = []
       "podDisruptive" = false

--- a/infra/modules/kubevela-addons/definitions/https-route.cue
+++ b/infra/modules/kubevela-addons/definitions/https-route.cue
@@ -26,6 +26,7 @@ outputs: {
         metadata: {
             annotations: {
                 "external-dns.alpha.kubernetes.io/hostname": parameter.domain
+                "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
             }
             name: _ingressName
             namespace: context.namespace
@@ -44,7 +45,7 @@ outputs: {
                         "/",
                     ][0]
                     pathType: [
-				        if rule.pathType != _|_ { rule.pathType},
+				        if rule.pathType != _|_ { rule.pathType },
                         "ImplementationSpecific",
                     ][0]
 			    	backend: service: {

--- a/infra/modules/kubevela-addons/definitions/https-route.cue
+++ b/infra/modules/kubevela-addons/definitions/https-route.cue
@@ -1,94 +1,60 @@
-import "strings"
-
 parameter: {
-	// +usage=Specify some domains, the domain may be prefixed with a wildcard label (*.)
-	domains: [...string]
+	// +usage=Specify the domain you want to expose
+	domain: string
+
 	// +usage=Specify some HTTP matchers, filters and actions.
 	rules: [...{
 		// +usage=An HTTP request path matcher. If this field is not specified, a default prefix match on the "/" path is provided.
 		path?: {
-			type:  *"PathPrefix" | "Exact"
+			pathType:  *"ImplementationSpecific" | "Exact" | "Prefix"
 			value: *"/" | string
-		}
-		// +usage=Conditions to select a HTTP route by matching HTTP request headers.
-		headers?: [...{
-			type:  "Exact"
-			name:  string
-			value: string
-		}]
-		// +usage=Specify the service name of component, the default is component name.
-		serviceName?: string
-		// +usage=Specify the service port of component.
-		port: int
-	}]
-	// +usage=Specify the gateway name
-	gatewayName?: *"traefik-gateway" | string
-	// +usage=Specify the listner name of the gateway
-	listenerName?: *"websecure" | string
+	    }
+        port: int
+    }]
+
+	// +usage=Specify the class of ingress to use
+	ingressClass?: *"nginx-public" | "nginx-internal"
 }
 
-outputs: {
-	_gatewayName: context.name + "-gateway"
-	gateway: {
-		apiVersion: "gateway.networking.k8s.io/v1alpha2"
-		kind:       "Gateway"
-		metadata: {
-			name:      _gatewayName
-			namespace: context.namespace
-		}
-		spec: {
-			gatewayClassName: "traefik"
-			listeners: [
-				for domain in parameter.domains {
-					_name:    strings.Replace(domain, ".", "-", -1) + "-https" // -1 means to replace all instances
-					name:     _name
-					protocol: "HTTP"
-					port:     8443
-					hostname: domain
-				},
-			]
-		}
-	}
+output: {}
 
-	httpsRoute: {
-		apiVersion: "gateway.networking.k8s.io/v1alpha2"
-		kind:       "HTTPRoute"
-		metadata: {
-			name:      context.name + "-https"
-			namespace: context.namespace
-		}
-		spec: {
-			parentRefs: [{
-				name:        _gatewayName
-				namespace:   context.namespace
-				port: 8443
-			}]
-			hostnames: parameter.domains
-			rules: [
-				for rule in parameter.rules {
-					{
-						matches: [
-							{
-								if rule.path != _|_ {
-									path: rule.path
-								}
-								if rule.headers != _|_ {
-									headers: rule.headers
-								}
-							},
-						]
-						backendRefs: [{
-							if rule.serviceName != _|_ {
-								name: rule.serviceName
-							}
-							if rule.serviceName == _|_ {
-								name: context.name
-							}
-							port: rule.port
-						}]
-					}
-				},
-			]
-		}
-	}
+outputs: {
+    _ingressName: context.name + "-ingress"
+    ingress: {
+        apiVersion: "networking.k8s.io/v1"
+        kind:       "Ingress"
+        metadata: {
+            annotations: {
+                "external-dns.alpha.kubernetes.io/hostname": parameter.domain
+            }
+            name: _ingressName
+            namespace: context.namespace
+        }
+        spec: { 
+            ingressClassName: [
+              if parameter.ingressClass != _|_ { parameter.ingressClass },
+              "nginx-public",
+            ][0]
+            rules: [{
+                host: parameter.domain
+			    http: paths: [
+			    for rule in parameter.rules {
+				    path: [
+                        if rule.path != _|_ { rule.path },
+                        "/",
+                    ][0]
+                    pathType: [
+				        if rule.pathType != _|_ { rule.pathType},
+                        "ImplementationSpecific",
+                    ][0]
+			    	backend: service: {
+				    	name: context.name
+					    if rule.port != _|_ {
+                            port: number: rule.port
+                        }
+				    }},
+		        ]
+            }
+        ]}
+    }
 }

--- a/infra/modules/kubevela-addons/definitions/https-route.cue
+++ b/infra/modules/kubevela-addons/definitions/https-route.cue
@@ -19,7 +19,6 @@ parameter: {
 output: {}
 
 outputs: {
-    _ingressName: context.name + "-ingress"
     ingress: {
         apiVersion: "networking.k8s.io/v1"
         kind:       "Ingress"
@@ -28,7 +27,7 @@ outputs: {
                 "external-dns.alpha.kubernetes.io/hostname": parameter.domains[0]
                 "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
             }
-            name: _ingressName
+            name: context.name
             namespace: context.namespace
         }
         spec: { 

--- a/infra/modules/kubevela-addons/definitions/https-route.cue
+++ b/infra/modules/kubevela-addons/definitions/https-route.cue
@@ -1,60 +1,59 @@
-parameter: {
-	// +usage=Specify the domain you want to expose
-	domains: [...string]
 
-	// +usage=Specify some HTTP matchers, filters and actions.
-	rules: [...{
-		// +usage=An HTTP request path matcher. If this field is not specified, a default prefix match on the "/" path is provided.
-		path?: {
-			pathType:  *"ImplementationSpecific" | "Exact" | "Prefix"
-			value: *"/" | string
-	    }
+parameter: {
+    // +usage=Specify the domain you want to expose
+    domains: [...string]
+
+    // +usage=Specify some HTTP matchers, filters and actions.
+    rules: [...{
+        // +usage=An HTTP request path matcher. If this field is not specified, a default prefix match on the "/" path is provided.
+        path?: {
+            pathType: *"ImplementationSpecific" | "Exact" | "Prefix"
+            value:    *"/" | string
+        }
         port: int
     }]
 
-	// +usage=Specify the ingress class to use
-	ingressClass?: *"public" | "internal"
+    // +usage=Specify the ingress class to use
+    ingressClass?: *"public" | "internal"
 }
 
 output: {}
 
-outputs: {
-    ingress: {
-        apiVersion: "networking.k8s.io/v1"
-        kind:       "Ingress"
-        metadata: {
-            annotations: {
-                "external-dns.alpha.kubernetes.io/hostname": parameter.domains[0]
-                "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
-            }
-            name: context.name
-            namespace: context.namespace
+outputs: ingress: {
+    apiVersion: "networking.k8s.io/v1"
+    kind:       "Ingress"
+    metadata: {
+        annotations: {
+            "external-dns.alpha.kubernetes.io/hostname":      parameter.domains[0]
+            "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
         }
-        spec: { 
-            ingressClassName: [
-              if parameter.ingressClass != _|_ { "nginx-\( parameter.ingressClass )" },
-              "nginx-public",
-            ][0]
-            rules: [{
-                host: parameter.domains[0]
-			    http: paths: [
-			    for rule in parameter.rules {
-				    path: [
-                        if rule.path != _|_ { rule.path },
+        name:      context.name
+        namespace: context.namespace
+    }
+    spec: {
+        ingressClassName: [
+            if parameter.ingressClass != _|_ {"nginx-\( parameter.ingressClass )"},
+            "nginx-public",
+        ][0]
+        rules: [{
+            host: parameter.domains[0]
+            http: paths: [
+                for rule in parameter.rules {
+                    path: [
+                        if rule.path != _|_ {rule.path},
                         "/",
                     ][0]
                     pathType: [
-				        if rule.pathType != _|_ { rule.pathType },
+                        if rule.pathType != _|_ {rule.pathType},
                         "ImplementationSpecific",
                     ][0]
-			    	backend: service: {
-				    	name: context.name
-					    if rule.port != _|_ {
+                    backend: service: {
+                        name: context.name
+                        if rule.port != _|_ {
                             port: number: rule.port
                         }
-				    }},
-		        ]
-            }
+                    }},
+            ]
+        },
         ]}
-    }
 }

--- a/infra/modules/kubevela-addons/definitions/https-route.cue
+++ b/infra/modules/kubevela-addons/definitions/https-route.cue
@@ -12,8 +12,8 @@ parameter: {
         port: int
     }]
 
-	// +usage=Specify the class of ingress to use
-	ingressClass?: *"nginx-public" | "nginx-internal"
+	// +usage=Specify the ingress class to use
+	ingressClass?: *"public" | "internal"
 }
 
 output: {}
@@ -33,7 +33,7 @@ outputs: {
         }
         spec: { 
             ingressClassName: [
-              if parameter.ingressClass != _|_ { parameter.ingressClass },
+              if parameter.ingressClass != _|_ { "nginx-\( parameter.ingressClass )" },
               "nginx-public",
             ][0]
             rules: [{

--- a/infra/modules/kubevela-addons/definitions/https-route.cue
+++ b/infra/modules/kubevela-addons/definitions/https-route.cue
@@ -1,6 +1,6 @@
 parameter: {
 	// +usage=Specify the domain you want to expose
-	domain: string
+	domains: [...string]
 
 	// +usage=Specify some HTTP matchers, filters and actions.
 	rules: [...{
@@ -25,7 +25,7 @@ outputs: {
         kind:       "Ingress"
         metadata: {
             annotations: {
-                "external-dns.alpha.kubernetes.io/hostname": parameter.domain
+                "external-dns.alpha.kubernetes.io/hostname": parameter.domains[0]
                 "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
             }
             name: _ingressName
@@ -37,7 +37,7 @@ outputs: {
               "nginx-public",
             ][0]
             rules: [{
-                host: parameter.domain
+                host: parameter.domains[0]
 			    http: paths: [
 			    for rule in parameter.rules {
 				    path: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the configuration for HTTPS routing by transitioning from multiple domains to a single domain parameter.
  - Streamlined the rules definition with the introduction of a `pathType` property.
  - Replaced the `gateway` and `httpsRoute` with a more standardized `ingress` object, enhancing compatibility and simplifying annotations.

- **Documentation**
  - Updated the documentation to reflect the new configuration structure and parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->