### PR TITLE
chore: updating storage.md with k8s-update-strategy info

### DIFF
--- a/doc/kubevela-definitions/storage.md
+++ b/doc/kubevela-definitions/storage.md
@@ -43,6 +43,12 @@ spec:
           resources:
             requests:
               storage: 5Gi
+    # When using EBS persistent volumes is recommended to add k8s-update-strategy trait
+    # It will avoid stuck rollouts with Pending pods, forever waiting for the volume allocation
+    - type: k8s-update-strategy
+      properties:
+        strategy:
+          type: Recreate
     type: webservice
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Kubernetes deployment configuration guide to include the `k8s-update-strategy` trait recommendation for avoiding stuck rollouts with Pending pods, advising the use of the "Recreate" strategy type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->