### PR TITLE
Add Grafana Oncall module and terragrunt config.

### DIFF
--- a/infra/grafana/on-call/terragrunt.hcl
+++ b/infra/grafana/on-call/terragrunt.hcl
@@ -1,0 +1,37 @@
+locals {
+  # Get provider configs
+  providers        = read_terragrunt_config("${get_parent_terragrunt_dir()}/provider-configs/providers.hcl")
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+  secret_vars      = yamldecode(sops_decrypt_file(find_in_parent_folders("secrets.yaml")))
+
+  grafana_oncall_access_token = local.secret_vars.grafana_cloud.grafana_oncall_access_token
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../modules/grafana-oncall"
+}
+
+inputs = {
+  oncall_access_token = local.grafana_oncall_access_token
+
+  team_name  = "SCDE"
+  team_email = "dev-empowerment@iohk.io"
+
+  usernames = [
+    "olaniyioshunbote",
+    "renebarbosa",
+    "oguzhanboran",
+    "danielthagard",
+    "shealevy1"
+  ]
+
+  slack_channels = [
+    "smart-contracts-dev-empowerment",
+    "uptime",
+    "sc-k8s-monitoring"
+  ]
+}

--- a/infra/grafana/on-call/terragrunt.hcl
+++ b/infra/grafana/on-call/terragrunt.hcl
@@ -22,11 +22,14 @@ inputs = {
   team_email = "dev-empowerment@iohk.io"
 
   usernames = [
-    "olaniyioshunbote",
+    "shealevy1",
     "renebarbosa",
+    "olaniyioshunbote",
+    "fentonhaslam",
     "oguzhanboran",
     "danielthagard",
-    "shealevy1"
+    "lorenzocalegari",
+    "rosariopulella"
   ]
 
   slack_channels = [
@@ -34,4 +37,6 @@ inputs = {
     "uptime",
     "sc-k8s-monitoring"
   ]
+
+  oncall_schedule_start_date = "2023-12-18T00:00:00"
 }

--- a/infra/modules/grafana-oncall/data-sources.tf
+++ b/infra/modules/grafana-oncall/data-sources.tf
@@ -1,0 +1,31 @@
+# ===================================== #
+# USERS
+# ===================================== #
+
+data "grafana_oncall_user" "users" {
+  provider = grafana.oncall
+
+  for_each = toset(var.usernames)
+  username = each.value
+}
+
+# ============================================== #
+# CHANNELS
+# ============================================== #
+
+data "grafana_oncall_slack_channel" "slack_channels" {
+  provider = grafana.oncall
+
+  for_each = toset(var.slack_channels)
+  name     = each.value
+}
+
+# ============================================== #
+# TEAMS
+# ============================================== #
+
+data "grafana_oncall_team" "team" {
+  provider = grafana.oncall
+
+  name = var.team_name
+}

--- a/infra/modules/grafana-oncall/main.tf
+++ b/infra/modules/grafana-oncall/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = ">= 1.41.0"
+    }
+  }
+}
+
+provider "grafana" {
+  alias = "oncall"
+
+  oncall_access_token = var.oncall_access_token
+  oncall_url          = "https://oncall-prod-us-central-0.grafana.net/oncall"
+}
+
+# resource "grafana_team" "team" {
+#   provider = grafana.oncall
+# 
+#   name    = var.team_name
+#   email   = var.team_email
+#   members = toset([for username, user in data.grafana_oncall_user.users : user.email])
+# }

--- a/infra/modules/grafana-oncall/notifications.tf
+++ b/infra/modules/grafana-oncall/notifications.tf
@@ -13,7 +13,7 @@ resource "grafana_oncall_route" "team_route" {
 
   integration_id      = grafana_oncall_integration.alertmanager.id
   escalation_chain_id = grafana_oncall_escalation_chain.team_escalation_chain.id
-  routing_regex       = "\"namespace\" *: *\"ops-.*\""
+  routing_regex       = "\"severity\": \"critical\""
   position            = 0
 }
 

--- a/infra/modules/grafana-oncall/notifications.tf
+++ b/infra/modules/grafana-oncall/notifications.tf
@@ -1,0 +1,54 @@
+resource "grafana_oncall_integration" "alertmanager" {
+  provider = grafana.oncall
+
+  name = "${var.team_name} AlertManager"
+  type = "alertmanager"
+  default_route {
+    escalation_chain_id = grafana_oncall_escalation_chain.team_escalation_chain.id
+  }
+}
+
+resource "grafana_oncall_route" "team_route" {
+  provider = grafana.oncall
+
+  integration_id      = grafana_oncall_integration.alertmanager.id
+  escalation_chain_id = grafana_oncall_escalation_chain.team_escalation_chain.id
+  routing_regex       = "\"namespace\" *: *\"ops-.*\""
+  position            = 0
+}
+
+resource "grafana_oncall_escalation_chain" "team_escalation_chain" {
+  provider = grafana.oncall
+
+  name = "${var.team_name} Escalation Chain"
+}
+
+# Notify users from on-call schedule
+resource "grafana_oncall_escalation" "team_notify_schedule_step" {
+  provider = grafana.oncall
+
+  escalation_chain_id          = grafana_oncall_escalation_chain.team_escalation_chain.id
+  type                         = "notify_on_call_from_schedule"
+  notify_on_call_from_schedule = grafana_oncall_schedule.team_schedule.id
+  position                     = 0
+}
+
+# Wait step for 5 Minutes
+resource "grafana_oncall_escalation" "team_wait_step" {
+  provider = grafana.oncall
+
+  escalation_chain_id = grafana_oncall_escalation_chain.team_escalation_chain.id
+  type                = "wait"
+  duration            = 300
+  position            = 1
+}
+
+# Notify default Slack channel step
+resource "grafana_oncall_escalation" "team_notify_step" {
+  provider = grafana.oncall
+
+  escalation_chain_id = grafana_oncall_escalation_chain.team_escalation_chain.id
+  type                = "notify_whole_channel"
+  important           = true
+  position            = 2
+}

--- a/infra/modules/grafana-oncall/shift.tf
+++ b/infra/modules/grafana-oncall/shift.tf
@@ -1,0 +1,25 @@
+resource "grafana_oncall_on_call_shift" "week_shift" {
+  provider = grafana.oncall
+
+  name       = "${var.team_name} Week Shift"
+  type       = "rolling_users"
+  start      = "2023-12-18T00:00:00"
+  duration   = 60 * 60 * 24 // 24 hours
+  frequency  = "weekly"
+  interval   = 2
+  by_day     = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"]
+  week_start = "MO"
+  rolling_users = [for username, user in data.grafana_oncall_user.users : [user.id]]
+  time_zone = "UTC"
+}
+
+resource "grafana_oncall_schedule" "team_schedule" {
+ provider  = grafana.oncall
+
+ name      = "${var.team_name} Calendar Schedule"
+ type      = "calendar"
+ time_zone = "UTC"
+ shifts    = [
+   grafana_oncall_on_call_shift.week_shift.id
+ ]
+}

--- a/infra/modules/grafana-oncall/shift.tf
+++ b/infra/modules/grafana-oncall/shift.tf
@@ -3,14 +3,16 @@ resource "grafana_oncall_on_call_shift" "week_shift" {
 
   name       = "${var.team_name} Week Shift"
   type       = "rolling_users"
-  start      = "2023-12-18T00:00:00"
+  start      = var.oncall_schedule_start_date
+  time_zone  = "UTC"
   duration   = 60 * 60 * 24 // 24 hours
   frequency  = "weekly"
-  interval   = 2
+  interval   = 1
   by_day     = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"]
   week_start = "MO"
+
   rolling_users = [for username, user in data.grafana_oncall_user.users : [user.id]]
-  time_zone = "UTC"
+  start_rotation_from_user_index = 1
 }
 
 resource "grafana_oncall_schedule" "team_schedule" {

--- a/infra/modules/grafana-oncall/shift.tf
+++ b/infra/modules/grafana-oncall/shift.tf
@@ -1,3 +1,11 @@
+# The oncall shift schedule operates on a week-long rotation
+# running from Monday to Sunday. Members of the schedule
+# are rotated weekly and are expected to have all their 
+# communication channels (at least Mobile App, Slack, and
+# Phone numbers) configured. Comms channels can be
+# configured from the link below: 
+# https://sctf.grafana.net/a/grafana-oncall-app/users?p=1
+
 resource "grafana_oncall_on_call_shift" "week_shift" {
   provider = grafana.oncall
 

--- a/infra/modules/grafana-oncall/variables.tf
+++ b/infra/modules/grafana-oncall/variables.tf
@@ -25,3 +25,8 @@ variable "slack_channels" {
   type        = list(string)
   default     = [ ]
 }
+
+variable "oncall_schedule_start_date" {
+  description = "Start date and time for oncall schedule"
+  type        = string
+}

--- a/infra/modules/grafana-oncall/variables.tf
+++ b/infra/modules/grafana-oncall/variables.tf
@@ -1,0 +1,27 @@
+variable "oncall_access_token" {
+  description = "Access token for Grafana Oncall system"
+  type        = string
+  sensitive   = true
+}
+
+variable "usernames" {
+  description = "List of users in the Oncall schedule"
+  type        = list(string)
+  default     = [ ]
+}
+
+variable "team_name" {
+  description = "Name of team using the oncall schedule"
+  type        = string
+}
+
+variable "team_email" {
+  description = "Email address of team using the oncall schedule"
+  type        = string
+}
+
+variable "slack_channels" {
+  description = "List of Slack channels notifications/alerts will be sent to"
+  type        = list(string)
+  default     = [ ]
+}

--- a/infra/modules/grafana-oncall/variables.tf
+++ b/infra/modules/grafana-oncall/variables.tf
@@ -29,4 +29,8 @@ variable "slack_channels" {
 variable "oncall_schedule_start_date" {
   description = "Start date and time for oncall schedule"
   type        = string
+  validation {
+    condition     = can(regex("^[0-9]{4}-[0-1][0-9]-[0-3][0-9]T[0-2][0-3]:[0-5][0-9]:[0-5][0-9]$", var.oncall_schedule_start_date))
+    error_message = "The oncall schedule start date must be a string in the format YYYY-MM-DDTHH:MM:SS e.g. '2025-09-17T13:46:28'."
+  }
 }

--- a/infra/secrets.yaml
+++ b/infra/secrets.yaml
@@ -1,23 +1,24 @@
 grafana_cloud:
-    api_key: ENC[AES256_GCM,data:cPBj+ibLJmt8EgmT603+/sW7ynXMUd3yqit+5Sd9ErZ4nnVAoY+68lMjrtgOZ8qEBtFWQNx5RdxgdPwnSovS8f+vMaIksQ/JH0uLWEo+XkZccWuOvG++aAsQ8DsCSXDUt6/T0AcWl7Fdv1kRhMPDwQYeHxW6Se3hs0RATvWysnfFNZrH7dzstrasrs5+79pDIHUFlzLKrmlGjJE2tyE1Ew==,iv:pWaG63c3q7Qsy+hnXltQ7JqwCPKhnPaVAHZkDxzl1og=,tag:hGSWPx1e8J+y/wXIqF65kQ==,type:str]
-    prometheus_username: ENC[AES256_GCM,data:DtRtcRyovw==,iv:BSHU+4KJ+z66a0s46r7kb69U+hLGnJgInO0EaWEAZK0=,tag:wkeS5MzWUUEZPg/ZQcjAAA==,type:str]
-    loki_username: ENC[AES256_GCM,data:wTWc4aEe,iv:d35DY2K6cpiM6g7KtjKyTQN0RjP2zUFJ+QLlVYIFqZc=,tag:GMQeU1o/iMDLGqECSj5DJA==,type:str]
-    tempo_username: ENC[AES256_GCM,data:TGg3zTou,iv:bmkgpUlGChOAxET5RNr0SgaoAuBr4lrztc9L8K5hskM=,tag:2viZ4X4mkIvVvCszgIttGQ==,type:str]
+    api_key: ENC[AES256_GCM,data:SbeUHK0sSe8RhEwjkZ7iXeZQAnVwpHzBcOFeTuGEwuRjZFVwUOi9JgWo1kBGtrW+GpxCjEthbmff9ENaZf4n+ipT3O/r6YMW6OBvJAr4vMnaPYXeaZ74zr/4EbZmzGgfTvEHZTynt8h7ggMIZs3c7mSQdHDzypBbiTssC02cwZE1hRqYs+6qaBLgdPf3t8S1hlPVG3YXpWiUTzvHOt4yyQ==,iv:a0lMBtcpx41Rz37Gshmciedcg+2vNo5pDUt4U9F+ing=,tag:NBZCj9jpClL6G8aoKNyNzg==,type:str]
+    prometheus_username: ENC[AES256_GCM,data:yn83tRIyRg==,iv:SdLLmWyBPI+fEMW4rHoMKwUi9kQgEHLG+Sb0IYbtvIM=,tag:RdbgFkOCHxDv+tWscWklpQ==,type:str]
+    loki_username: ENC[AES256_GCM,data:olrAyfgZ,iv:QfDslmWVNw2MuYnOa6OJp6QFFgUEA+lwrJOTHzEe8Ko=,tag:OdgsAmNVtitUCGpGmiSeqg==,type:str]
+    tempo_username: ENC[AES256_GCM,data:BrQM9NGR,iv:SLG3j03D/vAe09PMhmbPY0+/5BlWWZ4g+b/5gbdNopI=,tag:Kyz+pYTtFoKgZU8cAkkKuw==,type:str]
+    grafana_oncall_access_token: ENC[AES256_GCM,data:d8NZFS8Crmv0VdudLUZa/Qyx9ISWQ9jEcpNIQ3CzOZp2d76igN1Vrma9U5HPnRCP6FSpYSGag1utbADeEuhEEA==,iv:RmEnLnkLgsTGp9I8HofpANfjuB3/FfzzsUucivzwnVQ=,tag:5MdiHvxyO9mdC63GHN7zyw==,type:str]
 dex:
-    clientID: ENC[AES256_GCM,data:xb1i1gxI1CGAeiiVmIuQ0cbrgd838oRzA3YbUtUZNsmCWP7N5b2T8m9VUHH/5BFXWPl85Ujzm17xD+/w5Q1J22BllLRmj63M,iv:EzUsJus31z8jpkhSfppQLuZwfYzpQC7CmlgGXE2s9cs=,tag:2UsvGNRNEWFU8w03MFbXMQ==,type:str]
-    clientSecret: ENC[AES256_GCM,data:sj/6U1ABjyXfjSNWTsTIGX4t411lBsOHH/BiFJh1H3qTJ3g=,iv:8AOu8zk8gsLmCTswjzJ758VRgr5kc5H3HAK3eJKPf5w=,tag:FpxDILwWjafw8918w/GQ9Q==,type:str]
+    clientID: ENC[AES256_GCM,data:P8RVzACAIAtkwEtVQ+bY7HQslXBRmQrHc26uUGmfF1vDwrf1ntDRq38KZUW62L8mNtVqXLFteNb+zJgAa7QY6tLGe0ADfc1E,iv:OMH90eBFU7NEAtlAUyw2wdMgfOVz+VEplHo3F2si+AU=,tag:wCN6cw9F5/fZIqVRZoJFmA==,type:str]
+    clientSecret: ENC[AES256_GCM,data:xl7qw2Ej+Cl4bYD16yetVn8YV8Iso8WsfgRGOXSWorGMQrc=,iv:20rLL1SARo1CmaO7o39kQjDa+zRh/IgdYAcgkiEcRS8=,tag:sqZuGaldBPM0nVNbF8pHTw==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-east-1:677160962006:key/fa4d1d08-ad00-4014-97d2-5ff14e00e1b1
-          created_at: "2023-06-30T15:11:50Z"
-          enc: AQICAHgpALcUCbJ6IXIyoNVBg1oTqujiOETypdzUT4DiWJC8RwFsLaAQpL8wBMz9YUGdIE7/AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM30YhEbBXCQbpWtoZAgEQgDt99sUCVeKhG1QKLVmL7paPEgCa5H2yz16s0s3DcqxYXM0wEMJy7AOXxWoF8UMXf8J2CA5oGk0P1tdaMw==
-          aws_profile: dapps-world
+          created_at: "2023-12-12T17:39:34Z"
+          enc: AQICAHgpALcUCbJ6IXIyoNVBg1oTqujiOETypdzUT4DiWJC8RwFchnaodVaEgiVH0vP0B0kCAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMwGOzE3as0EGeQ330AgEQgDuIllxdhOfEjW5tnMUw8fh34sn40hLga+0NaF/EnLFr5GTcBpyNdojmEtYdJIxSKnamMNFXORBtqhC5dw==
+          aws_profile: ""
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-06T19:25:11Z"
-    mac: ENC[AES256_GCM,data:uqZ+Y9nVHJ8apScLXT7jdvDSRdfv+u/opRP0V+vG3+tOmO8qTF5A/o93ST1TtSIgojPYjdUKdUWWal6S6mKBlT1r8CrBdmkXv38rTV912W8/rWOJGt0O4oGCl7ckw2KTMJNHRJGI8qxhTIwmgyfZj+8alUjgisFd5Vllhkeapgs=,iv:osvr6uWCE/Fs7mq3Z3QT9PXSTJg2Tjev/d7Q3ambXtc=,tag:V2mmDAORai1dZVTRUeE0TQ==,type:str]
+    lastmodified: "2023-12-12T17:39:34Z"
+    mac: ENC[AES256_GCM,data:891OVf/BiszzWbk+ei0hkC0CWodSE638vTpzDV56bEysMrXaJ8h5Fav+zKkB9vg69ys3b4rypPAAcDK5Fh1kABTZnjvuGnqSiSavMiuw2mtDXu58NEoP76okZ7LM+OraGvmbNvs09aKnI1viGdzgrJS8VX9E/ddhqbhQtncjbm4=,iv:PI48Pt8Bd/H3WQf0ljsdFLKwz8JEosUsqGjVvPI/ZEg=,tag:CQlnvMiCWojB9EwfAdgLfQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced on-call scheduling with weekly shifts and calendar integration.
  - Added data retrieval configurations for users, Slack channels, and teams.
  - Implemented alert integration with routes, escalation chains, and Slack notifications.

- **Documentation**
  - Provided descriptions for new variables related to on-call access, team details, and scheduling.

- **Chores**
  - Established local variables and environment settings for Grafana on-call configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->