### PR TITLE
refactor: use route53 outputs instead of local values on acm

### DIFF
--- a/infra/us-east-1/prod/acm/terragrunt.hcl
+++ b/infra/us-east-1/prod/acm/terragrunt.hcl
@@ -5,7 +5,6 @@ locals {
   # Extract out common variables for reuse
   env     = local.environment_vars.locals.environment
   region  = local.environment_vars.locals.aws_region
-  domains = local.environment_vars.locals.route53_config
   profile = local.account_vars.locals.aws_profile
 }
 
@@ -14,10 +13,21 @@ include {
   path = find_in_parent_folders()
 }
 
+dependency "route53" {
+  config_path = "${get_repo_root()}/infra/global/route53/zones"
+}
+
 terraform {
-  source = "../../../modules/acm"
+  source = "${get_repo_root()}/infra/modules/acm"
 }
 
 inputs = {
-  domains = local.domains
+  domains = {
+    "scdev.aws.iohkdev.io"      = dependency.route53.outputs.route53_zone_zone_id["scdev.aws.iohkdev.io"]
+    "prod.scdev.aws.iohkdev.io" = dependency.route53.outputs.route53_zone_zone_id["scdev.aws.iohkdev.io"]
+    "demo.scdev.aws.iohkdev.io" = dependency.route53.outputs.route53_zone_zone_id["scdev.aws.iohkdev.io"]
+    "test.scdev.aws.iohkdev.io" = dependency.route53.outputs.route53_zone_zone_id["scdev.aws.iohkdev.io"]
+    "runner.marlowe.iohk.io"    = dependency.route53.outputs.route53_zone_zone_id["marlowe.iohk.io"]
+    "marlowe.iohk.io"           = dependency.route53.outputs.route53_zone_zone_id["marlowe.iohk.io"]
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Infrastructure Updates**
  - Improved domain management by integrating Route53 zone IDs directly into the ACM configuration.
  - Streamlined Terraform configurations for better maintainability and dynamic path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->