### PR TITLE
feat: using private link for grafana-agent

### DIFF
--- a/infra/account.hcl
+++ b/infra/account.hcl
@@ -4,10 +4,11 @@ locals {
   account_name   = "dapps-world"
   aws_account_id = "677160962006"
   #  aws_caller_arn = get_aws_caller_identity_arn()
-  aws_profile = "dapps-world"
-  name        = "scde"
-  project     = "scde"
-  tribe       = "smartcontracts"
+  aws_profile      = "dapps-world"
+  name             = "scde"
+  project          = "scde"
+  tribe            = "smartcontracts"
+  tf_bucket_region = "us-east-1"
   # Allow users to access k8s over aws_auth config
   users = [
     # SRE

--- a/infra/global/route53/records/marlowe-finance.io/terragrunt.hcl
+++ b/infra/global/route53/records/marlowe-finance.io/terragrunt.hcl
@@ -4,8 +4,8 @@ locals {
   account_vars     = read_terragrunt_config(find_in_parent_folders("account.hcl"))
 
   # Extract out common variables for reuse
-  project       = local.environment_vars.locals.project
-  tribe         = local.account_vars.locals.tribe
+  project = local.environment_vars.locals.project
+  tribe   = local.account_vars.locals.tribe
 }
 
 terraform {
@@ -30,7 +30,7 @@ inputs = {
       name = ""
       type = "A"
       alias = {
-        name = "s3-website.eu-central-1.amazonaws.com."
+        name    = "s3-website.eu-central-1.amazonaws.com."
         zone_id = "Z21DNDUVLTQW6Q"
       }
     },
@@ -38,7 +38,7 @@ inputs = {
       name = "play"
       type = "A"
       alias = {
-        name = "s3-website.eu-central-1.amazonaws.com."
+        name    = "s3-website.eu-central-1.amazonaws.com."
         zone_id = "Z21DNDUVLTQW6Q"
       }
     }

--- a/infra/global/route53/records/marlowe.iohk.io/terragrunt.hcl
+++ b/infra/global/route53/records/marlowe.iohk.io/terragrunt.hcl
@@ -4,8 +4,8 @@ locals {
   account_vars     = read_terragrunt_config(find_in_parent_folders("account.hcl"))
 
   # Extract out common variables for reuse
-  project       = local.environment_vars.locals.project
-  tribe         = local.account_vars.locals.tribe
+  project = local.environment_vars.locals.project
+  tribe   = local.account_vars.locals.tribe
 }
 
 terraform {
@@ -27,39 +27,39 @@ inputs = {
 
   records = [
     {
-      name = "play"
-      type = "NS"
-      ttl = 300
+      name    = "play"
+      type    = "NS"
+      ttl     = 300
       records = dependency.zones.outputs.route53_zone_name_servers["play.marlowe.iohk.io"]
     },
     {
-      name = "play-test"
-      type = "NS" 
-      ttl = 300
+      name    = "play-test"
+      type    = "NS"
+      ttl     = 300
       records = dependency.zones.outputs.route53_zone_name_servers["play-test.marlowe.iohk.io"]
     },
     {
-      name = "runner"
-      type = "NS"
-      ttl = 300
+      name    = "runner"
+      type    = "NS"
+      ttl     = 300
       records = dependency.zones.outputs.route53_zone_name_servers["runner.marlowe.iohk.io"]
     },
     {
-      name = "mpc"
-      type = "CNAME"
-      ttl = 300
+      name    = "mpc"
+      type    = "CNAME"
+      ttl     = 300
       records = ["8848114.group14.sites.hubspot.net."]
     },
     {
-      name = "docs" 
-      type = "CNAME" 
-      ttl = 300
+      name    = "docs"
+      type    = "CNAME"
+      ttl     = 300
       records = ["cname.vercel-dns.com."]
     },
     {
-      name = ""
-      type = "A"
-      ttl = 300
+      name    = ""
+      type    = "A"
+      ttl     = 300
       records = ["76.76.21.21"]
     }
   ]

--- a/infra/global/route53/records/us-east-2.vpce.grafana.net/terragrunt.hcl
+++ b/infra/global/route53/records/us-east-2.vpce.grafana.net/terragrunt.hcl
@@ -1,0 +1,62 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+  account_vars     = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  # Extract out common variables for reuse
+  project = local.environment_vars.locals.project
+  tribe   = local.account_vars.locals.tribe
+}
+
+terraform {
+  source = "github.com/terraform-aws-modules/terraform-aws-route53//modules/records?ref=v2.10.2"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+dependency "zones" {
+  config_path = "../../zones"
+}
+
+dependency "private_link" {
+  config_path = "${get_repo_root()}/infra/us-east-2/prod/grafana/private-link"
+}
+
+inputs = {
+
+  zone_name    = dependency.zones.outputs.route53_zone_name["us-east-2.vpce.grafana.net"]
+  private_zone = true
+
+  records = [
+    {
+      name = "cortex-prod-13-cortex-gw"
+      type = "A"
+      alias = {
+        name                   = dependency.private_link.outputs.endpoints.prometheus.dns_entry[0].dns_name
+        zone_id                = dependency.private_link.outputs.endpoints.prometheus.dns_entry[0].hosted_zone_id
+        evaluate_target_health = true
+      }
+    },
+    {
+      name = "loki-prod-006-cortex-gw"
+      type = "A"
+      alias = {
+        name                   = dependency.private_link.outputs.endpoints.loki.dns_entry[0].dns_name
+        zone_id                = dependency.private_link.outputs.endpoints.loki.dns_entry[0].hosted_zone_id
+        evaluate_target_health = true
+      }
+    },
+    {
+      name = "tempo-prod-04-cortex-gw"
+      type = "A"
+      alias = {
+        name                   = dependency.private_link.outputs.endpoints.tempo.dns_entry[0].dns_name
+        zone_id                = dependency.private_link.outputs.endpoints.tempo.dns_entry[0].hosted_zone_id
+        evaluate_target_health = true
+      }
+    }
+  ]
+}

--- a/infra/global/route53/zones/terragrunt.hcl
+++ b/infra/global/route53/zones/terragrunt.hcl
@@ -4,8 +4,8 @@ locals {
   account_vars     = read_terragrunt_config(find_in_parent_folders("account.hcl"))
 
   # Extract out common variables for reuse
-  project       = local.environment_vars.locals.project
-  tribe         = local.account_vars.locals.tribe
+  project = local.environment_vars.locals.project
+  tribe   = local.account_vars.locals.tribe
 }
 
 terraform {
@@ -15,6 +15,10 @@ terraform {
 # Include all settings from the root terragrunt.hcl file
 include {
   path = find_in_parent_folders()
+}
+
+dependency "vpc" {
+  config_path = "${get_repo_root()}/infra/us-east-1/prod/vpc"
 }
 
 inputs = {
@@ -43,6 +47,13 @@ inputs = {
       comment = "Marlowe Runner Production Domain"
     }
 
-    "marlowe-finance.io" = {} 
+    "marlowe-finance.io" = {}
+
+    "us-east-2.vpce.grafana.net" = {
+      comment = "Grafana Cloud Private Link Integration"
+      vpc = [{
+        vpc_id = dependency.vpc.outputs.vpc_id
+      }]
+    }
   }
 }

--- a/infra/terragrunt.hcl
+++ b/infra/terragrunt.hcl
@@ -38,13 +38,14 @@ locals {
   # Automatically load environment-level variables
   environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
   # Extract the variables we need for easy access
-  account_name = local.account_vars.locals.account_name
-  account_id   = local.account_vars.locals.aws_account_id
-  aws_profile  = local.account_vars.locals.aws_profile
-  tribe        = local.account_vars.locals.tribe
-  aws_region   = local.environment_vars.locals.aws_region
-  env          = local.environment_vars.locals.environment
-  project      = local.environment_vars.locals.project
+  account_name     = local.account_vars.locals.account_name
+  account_id       = local.account_vars.locals.aws_account_id
+  aws_profile      = local.account_vars.locals.aws_profile
+  tf_bucket_region = local.account_vars.locals.tf_bucket_region
+  tribe            = local.account_vars.locals.tribe
+  aws_region       = local.environment_vars.locals.aws_region
+  env              = local.environment_vars.locals.environment
+  project          = local.environment_vars.locals.project
 }
 
 # Generate an AWS provider block
@@ -90,9 +91,9 @@ remote_state {
   backend = "s3"
   config = {
     encrypt        = true
-    bucket         = "${get_env("TG_BUCKET_PREFIX", "")}tf-state-${local.account_name}-${local.aws_region}"
+    bucket         = "${get_env("TG_BUCKET_PREFIX", "")}tf-state-${local.account_name}-${local.tf_bucket_region}"
     key            = "${path_relative_to_include()}/terraform.tfstate"
-    region         = local.aws_region
+    region         = "${local.tf_bucket_region}"
     dynamodb_table = "terraform-locks"
     profile        = local.aws_profile
   }
@@ -113,6 +114,5 @@ remote_state {
 # where terraform_remote_state data sources are placed directly into the modules.
 inputs = merge(
   local.account_vars.locals,
-  local.environment_vars.locals,
   local.environment_vars.locals,
 )

--- a/infra/us-east-1/prod/peering/grafana/terragrunt.hcl
+++ b/infra/us-east-1/prod/peering/grafana/terragrunt.hcl
@@ -1,0 +1,53 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+  account_vars     = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  # Extract out common variables for reuse
+  env     = local.environment_vars.locals.environment
+  project = local.environment_vars.locals.project
+  profile = local.account_vars.locals.aws_profile
+  tribe   = local.account_vars.locals.tribe
+  name    = "grafana-vpc-peering"
+
+  # AWS Regions
+  requester_region = local.environment_vars.locals.aws_region
+  accepter_region  = "us-east-2"
+}
+
+terraform {
+  source = "github.com/cloudposse/terraform-aws-vpc-peering-multi-account?ref=0.19.1"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+# Requester VPC
+dependency "vpc_us_east_1" {
+  config_path = "${get_repo_root()}/infra/us-east-1/prod/vpc"
+}
+
+# Accepter VPC
+dependency "vpc_us_east_2" {
+  config_path = "${get_repo_root()}/infra/us-east-2/prod/grafana/vpc"
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  # Requester inputs
+  requester_aws_assume_role_arn = "" # This disables assume-role function
+  requester_aws_profile         = local.profile
+  requester_region              = local.requester_region
+  requester_vpc_id              = dependency.vpc_us_east_1.outputs.vpc_id
+
+  # Accepter inputs
+  accepter_aws_profile = local.profile
+  accepter_region      = local.accepter_region
+  accepter_vpc_id      = dependency.vpc_us_east_2.outputs.vpc_id
+
+  # Common inputs
+  auto_accept                               = true
+  requestor_allow_remote_vpc_dns_resolution = true
+  acceptor_allow_remote_vpc_dns_resolution  = true
+}

--- a/infra/us-east-2/prod/env.hcl
+++ b/infra/us-east-2/prod/env.hcl
@@ -1,0 +1,8 @@
+# Set common variables for the environment. This is automatically pulled in in the root terragrunt.hcl configuration to
+# feed forward to the child modules.
+locals {
+  aws_region  = "us-east-2"
+  environment = "prod"
+  project     = "scde"
+  cidr_prefix = "10.200"
+}

--- a/infra/us-east-2/prod/grafana/private-link/terragrunt.hcl
+++ b/infra/us-east-2/prod/grafana/private-link/terragrunt.hcl
@@ -1,0 +1,84 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+  account_vars     = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  # Extract out common variables for reuse
+  env     = local.environment_vars.locals.environment
+  region  = local.environment_vars.locals.aws_region
+  profile = local.account_vars.locals.aws_profile
+
+  # Grafana Cloud
+  service_names = {
+    prometheus = "com.amazonaws.vpce.us-east-2.vpce-svc-0d13a270cd91a0a3a"
+    loki       = "com.amazonaws.vpce.us-east-2.vpce-svc-071e7d98821c1698b"
+    tempo      = "com.amazonaws.vpce.us-east-2.vpce-svc-0a830aaea99ecfc91"
+  }
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+dependency "vpc_us_east_1" {
+  config_path = "${get_repo_root()}/infra/us-east-1/prod/vpc"
+}
+
+dependency "vpc_us_east_2" {
+  config_path = "${get_repo_root()}/infra/us-east-2/prod/grafana/vpc"
+}
+
+terraform {
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc//modules/vpc-endpoints?ref=v5.1.1"
+}
+
+inputs = {
+  vpc_id = dependency.vpc_us_east_2.outputs.vpc_id
+
+  endpoints = {
+    prometheus = {
+      service_name        = local.service_names.prometheus
+      service_type        = "Interface"
+      subnet_ids          = dependency.vpc_us_east_2.outputs.private_subnets
+      private_dns_enabled = true
+      tags = {
+        Name = "grafana-cloud-prometheus"
+      }
+    }
+    loki = {
+      service_name        = local.service_names.loki
+      service_type        = "Interface"
+      subnet_ids          = dependency.vpc_us_east_2.outputs.private_subnets
+      private_dns_enabled = true
+      tags = {
+        Name = "grafana-cloud-loki"
+      }
+    }
+    tempo = {
+      service_name        = local.service_names.tempo
+      service_type        = "Interface"
+      subnet_ids          = dependency.vpc_us_east_2.outputs.private_subnets
+      private_dns_enabled = true
+      tags = {
+        Name = "grafana-cloud-tempo"
+      }
+    }
+  }
+
+  create_security_group      = true
+  security_group_name_prefix = "grafana-private-link-sg-"
+  security_group_description = "Grafana Private Link Endpoint SecurityGroup"
+  security_group_rules = {
+    ingress_grafana_cloud = {
+      description = "Enable Grafana Cloud connection from Prod VPC"
+      cidr_blocks = dependency.vpc_us_east_1.outputs.private_subnets_cidr_blocks
+    }
+    egress_default_rule = {
+      type      = "egress"
+      from_port = 0
+      to_port   = 65535
+      protocol  = "all"
+      self      = true
+    }
+  }
+}

--- a/infra/us-east-2/prod/grafana/vpc/terragrunt.hcl
+++ b/infra/us-east-2/prod/grafana/vpc/terragrunt.hcl
@@ -1,0 +1,40 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+  account_vars     = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  # Extract out common variables for reuse
+  env         = local.environment_vars.locals.environment
+  region      = local.environment_vars.locals.aws_region
+  cidr_prefix = local.environment_vars.locals.cidr_prefix
+  project     = local.environment_vars.locals.project
+  tribe       = local.account_vars.locals.tribe
+  name        = "grafana-cloud"
+}
+
+terraform {
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v5.1.1"
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  name = local.name
+  cidr = "${local.cidr_prefix}.0.0/16"
+
+  azs             = ["${local.region}a", "${local.region}b"]
+  private_subnets = ["${local.cidr_prefix}.0.0/20", "${local.cidr_prefix}.16.0/20"] # /20 will allow 4096 ips per subnet
+
+  enable_nat_gateway     = false
+  single_nat_gateway     = true
+  one_nat_gateway_per_az = false
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  map_public_ip_on_launch       = false
+  manage_default_network_acl    = true
+  manage_default_route_table    = true
+  manage_default_security_group = true
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new Terraform configurations for VPC peering and private link endpoints for Grafana.
  - Added dynamic URL retrievals for Grafana services using Route53 records.

- **Enhancements**
  - Streamlined AWS account and Terraform state configuration variables.

- **Bug Fixes**
  - Removed hard-coded URLs in Grafana agent configuration, now using dynamic service discovery.

- **Refactor**
  - Reorganized variable assignments and dependencies for clarity and maintainability.
  - Standardized formatting and indentation across multiple configuration files.

- **Documentation**
  - Added comments and documentation for new zone entries and VPC configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->