### PR TITLE
hotfix: sops decrypt

### DIFF
--- a/infra/secrets.yaml
+++ b/infra/secrets.yaml
@@ -12,7 +12,7 @@ sops:
         - arn: arn:aws:kms:us-east-1:677160962006:key/fa4d1d08-ad00-4014-97d2-5ff14e00e1b1
           created_at: "2023-12-12T17:39:34Z"
           enc: AQICAHgpALcUCbJ6IXIyoNVBg1oTqujiOETypdzUT4DiWJC8RwFchnaodVaEgiVH0vP0B0kCAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMwGOzE3as0EGeQ330AgEQgDuIllxdhOfEjW5tnMUw8fh34sn40hLga+0NaF/EnLFr5GTcBpyNdojmEtYdJIxSKnamMNFXORBtqhC5dw==
-          aws_profile: ""
+          aws_profile: "dapps-world"
     gcp_kms: []
     azure_kv: []
     hc_vault: []


### PR DESCRIPTION
Setting `aws_profile` directly on secrets.yaml to avoid errors when running terragrunt without `AWS_PROFILE` environment variable previously defined.