### PR TITLE
doc: node-connector updates

### DIFF
--- a/doc/kubevela-definitions/cardano/node-connector.md
+++ b/doc/kubevela-definitions/cardano/node-connector.md
@@ -5,8 +5,7 @@
 The Cardano Node Connector in Kubvela acts as a bridge between your application and the Cardano node through specific application characteristics and settings
 
 The ***required*** parameter for implementing this trait is:
- - `network`: Defines the network choice for the Cardano Node, with a default setting as "preview". 
-<br>The other options available are "preprod" and "mainnet".
+ - `network`: Defines the network choice for the Cardano Node. The available options are "preview", "preprod" and "mainnet".
 
 This configuration effectively attaches specific volumes to each container that is part of your application. Also, a `socat` container bridges your application and the Cardano Node by utilizing TCP Socket over a UNIX Socket.
 
@@ -34,3 +33,7 @@ spec:
       properties:
         network: preview
 ```
+
+Once this Application definition is applied, the socket will be available in `/ipc/node.socket` which is mounted through an emptyDir volume and shared between the containers. Please note the socket path is also available on `CARDANO_NODE_SOCKET_PATH` environment variable.
+
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the description for the `network` parameter options in the Cardano Node Connector trait to include "preview", "preprod", and "mainnet".
	- Added a note on the availability and path of the socket for the Cardano Node Connector once applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->