### PR TITLE
fix: adding nodeSelector to avoid pending jobs (waiting for ebs volume)

### DIFF
--- a/infra/datasync/datasync.yaml
+++ b/infra/datasync/datasync.yaml
@@ -103,4 +103,5 @@ spec:
             persistentVolumeClaim:
               claimName: datasync-pvc
           restartPolicy: OnFailure
-
+          nodeSelector:
+            topology.kubernetes.io/zone: "us-east-1b"

--- a/infra/datasync/secret.enc.yaml
+++ b/infra/datasync/secret.enc.yaml
@@ -1,7 +1,7 @@
 apiVersion: ENC[AES256_GCM,data:15s=,iv:aNOqbY2437njfWDJTm0LAJ5HWTVWfB61Ru979bbP6Fc=,tag:Z/9D+kqH/OVuEdNqTvXG8g==,type:str]
 data:
     endpoint: ENC[AES256_GCM,data:Nlf0Q2JL71yiJf0DP/1FOaLs+Ypeye8tHwmlGb+zyF58huG82NA6tCkaGGczP2YLd5yYJQ/AN7mptGQm0kcF7sXhZbjxceT76gM1TyfleWyXRxsR9FduwqV7Ekrzlj0U,iv:5cLTU7Q7lFNFyxioqnuQCj5t1SDvYhcAO+MmMzXcbgE=,tag:Mee1wVyIn6Fc4pr1nGuiGw==,type:str]
-    password: ENC[AES256_GCM,data:e3wViw7yzE+zPrwJ437Dnhq5pENrVqya8yC+Pyn2ZXyBdKugrbZTQQ==,iv:AEhJBuS4W0iDli2y3iP+WFWKs8vyz+dyRJYTF3OicjU=,tag:vmgjlYpt0DvaiwJCqOQFhw==,type:str]
+    password: ENC[AES256_GCM,data:o5OV1WZGncA5hJrI96yWygEd7FOoFZKLAYa3C1xn3iCTs6FTNE7ZRQ==,iv:tRvYxEinWryo/IPqeIc90DQIKd8m54UECHgYaFCKWng=,tag:mYJXPELm3cUVnmlvxRxefQ==,type:str]
     port: ENC[AES256_GCM,data:0bUv3E9wAPI=,iv:SHrh7ItaKuidpfljLyJspMK7W9bXrdUC7aX+0Boc6+Y=,tag:fmkNd3h5zAQ1rA/EieFj/g==,type:str]
     username: ENC[AES256_GCM,data:BtYTQIe/HUH2e18m,iv:HyAdKZq+tbk825PNK6yAYJdfjH0ek6hNy+S25A9vToI=,tag:4RbVCB7n5/Xm4LbEkBuXAw==,type:str]
 kind: ENC[AES256_GCM,data:cUFLpur/,iv:u37E0obvYWymsh2X8chzMflBzuJ1V4CocGTXWnvT6Ts=,tag:63I+ahxU30PyoSNOXBSZWQ==,type:str]
@@ -14,13 +14,13 @@ sops:
         - arn: arn:aws:kms:us-east-1:677160962006:key/fa4d1d08-ad00-4014-97d2-5ff14e00e1b1
           created_at: "2024-01-17T13:58:35Z"
           enc: AQICAHgpALcUCbJ6IXIyoNVBg1oTqujiOETypdzUT4DiWJC8RwEyGwGuOsVU77TFAOp9zapTAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMMOj7upTGZV0lUdsBAgEQgDtRt8hsDEmPiRNkn2hrdpUTb+mWSZW8oPNMrpmkmU/ABxptq/EOHrjajnbDnxsYsANIQ3g6sP12dwWiIg==
-          aws_profile: "dapps-world"
+          aws_profile: dapps-world
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-01-17T13:58:36Z"
-    mac: ENC[AES256_GCM,data:7KR/LnzbXE33tO9apnCX/BJSwYoUA+vRR3Pjd/FWI8FdmQCWEaWa/RQL6yXgmR7tdwH32puLdnZY1pxHrd0oG45i1WCnFAmhzQ6HncU7qjQ4j5VJp0xfeGEdN7LIvss6EbbzS9vBal9COm0HpGQ9yxQv8U2u89FZ6aLbDnkhqOA=,iv:YRBxGloU7bTdV3rfRD4vq3jPDA7Uf/sO2SmekTL6/jU=,tag:0pp2m+da6hvZnhc56EXH6g==,type:str]
+    lastmodified: "2024-01-23T12:56:35Z"
+    mac: ENC[AES256_GCM,data:f5NUsv2qcpXEd26mImh7JDugqkDPG7qEgnxrtNmu9LC+7EXEAbpM21QvoM5gZOV6yGEWlsRKUznVg+aHhPSPM921OV0A307T0hQTiOs0lvQkE/efLLoghxXcPc8QmZfrf4Cjl2D7ERsYRGo+aeRiepfFhb4SLR7P4EWYV4v0hWY=,iv:IiPvnJB732UF7XImzT7YXUsvoDQOm3v42fdoePolAmg=,tag:ed61jL+JXiWN3uyYXnCSlQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1


### PR DESCRIPTION
Adding a nodeSelector to prevent pods stuck in `Pending` (waiting for EBS volumes).