### PR TITLE
fix: CVE-2024-21626

### DIFF
--- a/infra/us-east-1/dev/eks/cluster/terragrunt.hcl
+++ b/infra/us-east-1/dev/eks/cluster/terragrunt.hcl
@@ -62,7 +62,7 @@ inputs = {
   eks_managed_node_group_defaults = {
     # aws ssm get-parameters-by-path --path /aws/service/bottlerocket/aws-k8s-1.26/x86_64/latest/ --region us-east-1 \
     # --recursive | jq -r '.Parameters[1].Value'
-    ami_release_version = "1.16.0-d2d9cf87"
+    ami_release_version = "1.19.0-2b1a7872"
   }
 
   eks_managed_node_groups = {

--- a/infra/us-east-1/dev/eks/kubevela-addons/terragrunt.hcl
+++ b/infra/us-east-1/dev/eks/kubevela-addons/terragrunt.hcl
@@ -41,7 +41,7 @@ inputs = {
   oidc_provider_arn                  = dependency.eks.outputs.oidc_provider_arn
   rds_security_groups                = [dependency.security_group.outputs.security_group_id]
   enable_addons                      = true 
-  enable_cardano_nodes               = true 
+  enable_cardano_nodes               = false 
   enable_dex                         = false
   enable_cluster_secrets             = false
 }

--- a/infra/us-east-1/prod/eks/green/eks/terragrunt.hcl
+++ b/infra/us-east-1/prod/eks/green/eks/terragrunt.hcl
@@ -60,7 +60,7 @@ inputs = {
   control_plane_subnet_ids = dependency.vpc.outputs.intra_subnets
 
   eks_managed_node_group_defaults = {
-    ami_release_version = "1.15.1-264e294c"
+    ami_release_version = ""1.19.0-2b1a7872"
   }
 
   eks_managed_node_groups = {

--- a/infra/us-east-1/prod/eks/green/eks/terragrunt.hcl
+++ b/infra/us-east-1/prod/eks/green/eks/terragrunt.hcl
@@ -60,7 +60,7 @@ inputs = {
   control_plane_subnet_ids = dependency.vpc.outputs.intra_subnets
 
   eks_managed_node_group_defaults = {
-    ami_release_version = ""1.19.0-2b1a7872"
+    ami_release_version = "1.19.0-2b1a7872"
   }
 
   eks_managed_node_groups = {

--- a/infra/us-east-1/prod/eks/green/eks/terragrunt.hcl
+++ b/infra/us-east-1/prod/eks/green/eks/terragrunt.hcl
@@ -73,7 +73,7 @@ inputs = {
     }
     "worker-memory" = {
       min_size       = 3
-      max_size       = 9
+      max_size       = 12
       instance_types = ["t3a.2xlarge"]
       subnet_ids     = dependency.vpc.outputs.private_subnets
       labels = {

--- a/infra/us-east-1/prod/eks/green/eks/terragrunt.hcl
+++ b/infra/us-east-1/prod/eks/green/eks/terragrunt.hcl
@@ -73,7 +73,7 @@ inputs = {
     }
     "worker-memory" = {
       min_size       = 3
-      max_size       = 12
+      max_size       = 15
       instance_types = ["t3a.2xlarge"]
       subnet_ids     = dependency.vpc.outputs.private_subnets
       labels = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the AMI release version for EKS managed node groups in both development and production environments to enhance performance and security.
	- Adjusted the maximum size for the "worker-memory" node group in the production environment from 9 to 12.
	- Disabled Cardano nodes in the kubevela-addons configuration for the development EKS environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->